### PR TITLE
MarketWatcher fixes - Closes #34

### DIFF
--- a/config.global.js
+++ b/config.global.js
@@ -6,6 +6,6 @@ config.freegeoip = {};
 config.redis = {};
 config.proposals = {};
 config.exchangeRates = {exchanges: { ARK: {}, BTC: {}}};
-config.marketWatcher = {exchanges: {}, candles: {}, orders: {}};
+config.marketWatcher = {exchanges: {}, candles: { poloniex: {} }, orders: {}};
 
 module.exports = config;

--- a/config.js
+++ b/config.js
@@ -38,6 +38,7 @@ config.marketWatcher.enabled = true; // Market watcher support (true - enabled, 
 config.marketWatcher.exchanges.poloniex = false; // Poloniex exchange support (true - enabled, false - disabled)
 config.marketWatcher.exchanges.bittrex  = true; // Bittrex exchange support (true - enabled, false - disabled)
 config.marketWatcher.candles.updateInterval = 30000; // Interval in ms for updating candlestick data (default: 30 seconds)
+config.marketWatcher.candles.poloniex.buildTimeframe = 60*60*24*30; // Build candles based on trades form last 30 days
 config.marketWatcher.orders.updateInterval  = 15000;  // Interval in ms for updating order book data (default: 15 seconds)
 
 // Delegate Proposals

--- a/config.js
+++ b/config.js
@@ -34,8 +34,8 @@ config.exchangeRates.exchanges.BTC.EUR = 'bitstamp';  // BTC/EUR pair, supported
 config.exchangeRates.exchanges.BTC.PLN = 'bitmarket'; // BTC/PLN pair, supported: bitmarket
 
 // Market watcher
-config.marketWatcher.enabled = false; // Market watcher support (true - enabled, false - disabled)
-config.marketWatcher.exchanges.poloniex = true; // Poloniex exchange support (true - enabled, false - disabled)
+config.marketWatcher.enabled = true; // Market watcher support (true - enabled, false - disabled)
+config.marketWatcher.exchanges.poloniex = false; // Poloniex exchange support (true - enabled, false - disabled)
 config.marketWatcher.exchanges.bittrex  = true; // Bittrex exchange support (true - enabled, false - disabled)
 config.marketWatcher.candles.updateInterval = 30000; // Interval in ms for updating candlestick data (default: 30 seconds)
 config.marketWatcher.orders.updateInterval  = 15000;  // Interval in ms for updating order book data (default: 15 seconds)

--- a/lib/candles/abstract.js
+++ b/lib/candles/abstract.js
@@ -11,7 +11,8 @@ function AbstractCandles (client) {
     this.name  = 'exchange';
     this.key   = this.name + 'Candles';
     this.url   = '';
-    this.start = 0;
+    this.start = null;
+    this.end   = null;
     this.last  = null;
 
     this.response = {
@@ -29,9 +30,7 @@ function AbstractCandles (client) {
     this.duration  = 'minute';
     this.durations = ['minute', 'hour', 'day'];
 
-    this.retrieveTrades = function (start, cb) {
-        if (!start) { start = self.start || 0; }
-
+    this.retrieveTrades = function (start, end, cb) {
         var found   = false,
             results = [];
 
@@ -39,9 +38,11 @@ function AbstractCandles (client) {
 
         async.doUntil(
             function (next) {
+                console.log ('Candles: Start: ' + (start ? new Date(start*1000).toISOString() : 'N/A') + ' End: ' + (end ? new Date(end*1000).toISOString() : 'N/A'));
+
                 request.get({
-                    url : self.url + start,
-                    json : true
+                    url: self.url + (start ? '&start=' + start : '') + (end ? '&end=' + end : ''),
+                    json: true
                 }, function (err, resp, body) {
                     if (err || resp.statusCode !== 200) {
                         return next(err || 'Response was unsuccessful');
@@ -59,9 +60,9 @@ function AbstractCandles (client) {
                     }
 
                     if (self.validTrades(results, data)) {
-                        console.log('Candles:', start.toString(), '=> Found', data.length.toString(), 'trades');
+                        console.log('Candles:', (start ? start.toString() : 'N/A'), 'to', (end ? end.toString() : 'N/A'), '=> Found', data.length.toString(), 'trades');
                         results = self.acceptTrades(results, data);
-                        start   = self.nextStart(data);
+                        end     = self.nextEnd(data);
                         return next();
                     } else {
                         found = true;
@@ -83,8 +84,8 @@ function AbstractCandles (client) {
         );
     };
 
-    this.nextStart = function (data) {
-        return 0;
+    this.nextEnd = function (data) {
+        return null;
     };
 
     this.rejectTrades = function (data) {
@@ -151,7 +152,7 @@ function AbstractCandles (client) {
                 btcVolume  : _.reduce(period, function (memo, t) { return (memo + parseFloat(t[self.candle.amount]) * parseFloat(t[self.candle.price])); }, 0.0).toFixed(8),
                 firstTrade : _.first(period)[self.candle.id],
                 lastTrade  : _.last(period)[self.candle.id],
-                nextStart  : self.nextStart(period),
+                nextEnd    : self.nextEnd(period),
                 numTrades  : _.size(period)
             };
         });
@@ -201,39 +202,53 @@ function AbstractCandles (client) {
     };
 
     this.buildCandles = function (cb) {
-        async.eachSeries(self.durations, function (duration, callback) {
-            self.duration = duration;
-            _buildCandles(callback);
-        }, function (err, results) {
+        async.waterfall([
+            function (waterCb) {
+                return self.retrieveTrades(self.start, self.end, waterCb);
+            },
+            function (trades, waterCb) {
+                async.eachSeries(self.durations, function (duration, eachCb) {
+                    self.duration = duration;
+                    return _buildCandles(trades, eachCb);
+                }, function (err, results) {
+                    if (err) {
+                        return waterCb(err);
+                    } else {
+                        return waterCb(null);
+                    }
+                });
+            }
+        ],
+        function (err, results) {
             if (err) {
                 return cb(err);
             } else {
-                return cb(null);
+                return cb(null, results);
             }
         });
     };
 
-    var _buildCandles = function (cb) {
+    var _buildCandles = function (trades, cb) {
         console.log('Candles:', 'Building', self.duration, 'candles for', self.name + '...');
 
         async.waterfall([
-            function (callback) {
+            function (waterCb) {
                 client.DEL(self.candleKey(), function (err, res) {
                     if (err) {
-                        return callback(err);
+                        return waterCb(err);
                     } else {
-                        self.retrieveTrades(null, callback);
+                        return waterCb();
                     }
                 });
             },
-            function (results, callback) {
-                self.groupTrades(results, callback);
+            function (waterCb) {
+                return self.groupTrades(trades, waterCb);
             },
-            function (results, callback) {
-                self.sumTrades(results, callback);
+            function (results, waterCb) {
+                return self.sumTrades(results, waterCb);
             },
-            function (results, callback) {
-                self.saveCandles(results, callback);
+            function (results, waterCb) {
+                return self.saveCandles(results, waterCb);
             }
         ],
         function (err, results) {
@@ -246,21 +261,6 @@ function AbstractCandles (client) {
     };
 
     this.updateCandles = function (cb) {
-        async.eachSeries(self.durations, function (duration, callback) {
-            self.duration = duration;
-            _updateCandles(callback);
-        }, function (err, results) {
-            if (err) {
-                return cb(err);
-            } else {
-                return cb(null);
-            }
-        });
-    };
-
-    var _updateCandles = function (cb) {
-        console.log('Candles:', 'Updating', self.duration, 'candles for', self.name + '...');
-
         async.waterfall([
             function (callback) {
                 client.LRANGE(self.candleKey(), -1, -1, function (err, reply) {
@@ -274,17 +274,43 @@ function AbstractCandles (client) {
                     }
                 });
             },
-            function (reply, callback) {
-                return self.retrieveTrades(reply.nextStart, callback);
+            function (last, waterCb) {
+                return self.retrieveTrades(last.nextEnd, null, waterCb);
             },
-            function (results, callback) {
-                return self.groupTrades(results, callback);
+            function (trades, waterCb) {
+                async.eachSeries(self.durations, function (duration, eachCb) {
+                    self.duration = duration;
+                    return _updateCandles(trades, eachCb);
+                }, function (err, results) {
+                    if (err) {
+                        return waterCb(err);
+                    } else {
+                        return waterCb(null);
+                    }
+                });
+            }
+        ],
+        function (err, results) {
+            if (err) {
+                return cb(err);
+            } else {
+                return cb(null);
+            }
+        });
+    };
+
+    var _updateCandles = function (trades, cb) {
+        console.log('Candles:', 'Updating', self.duration, 'candles for', self.name + '...');
+
+        async.waterfall([
+            function (waterCb) {
+                return self.groupTrades(trades, waterCb);
             },
-            function (results, callback) {
-                return self.sumTrades(results, callback);
+            function (results, waterCb) {
+                return self.sumTrades(results, waterCb);
             },
-            function (results, callback) {
-                return self.saveCandles(results, callback);
+            function (results, waterCb) {
+                return self.saveCandles(results, waterCb);
             }
         ],
         function (err, results) {

--- a/lib/candles/bittrex.js
+++ b/lib/candles/bittrex.js
@@ -28,10 +28,6 @@ function BittrexCandles (client) {
         amount : 'Quantity'
     };
 
-    this.nextStart = function (data) {
-        return moment(_.last(data).date).add(1, 's').unix();
-    };
-
     this.acceptTrades = function (results, data) {
         return results.concat(data.reverse());
     };

--- a/lib/candles/poloniex.js
+++ b/lib/candles/poloniex.js
@@ -5,14 +5,14 @@ var AbstractCandles = require('./abstract'),
     _ = require('underscore'),
     util = require('util');
 
-function PoloniexCandles (client) {
+function PoloniexCandles (client, params) {
     var self = this;
 
     AbstractCandles.apply(this, arguments);
 
-    var now = new Date();
-    this.start = Math.floor(now.setYear(now.getFullYear() - 1) / 1000); // Unix timestamp 1 year ago (in sec)
-    this.end   = Math.floor(Date.now() / 1000); // Current unix timestamp (in sec)
+    var now = Math.floor(Date.now() / 1000);
+    this.start = params && params.buildTimeframe ? (now - params.buildTimeframe) : null;
+    this.end   = now; // Current unix timestamp (in sec)
 
     this.name  = 'poloniex';
     this.key   = this.name + 'Candles';

--- a/lib/candles/poloniex.js
+++ b/lib/candles/poloniex.js
@@ -10,10 +10,13 @@ function PoloniexCandles (client) {
 
     AbstractCandles.apply(this, arguments);
 
+    var now = new Date();
+    this.start = Math.floor(now.setYear(now.getFullYear() - 1) / 1000); // Unix timestamp 1 year ago (in sec)
+    this.end   = Math.floor(Date.now() / 1000); // Current unix timestamp (in sec)
+
     this.name  = 'poloniex';
     this.key   = this.name + 'Candles';
-    this.url   = 'https://poloniex.com/public?command=returnTradeHistory&currencyPair=BTC_ARK&start=';
-    this.start = 1464126157; // 2016-05-24 00:00:00 GMT
+    this.url   = 'https://poloniex.com/public?command=returnTradeHistory&currencyPair=BTC_LSK';
 
     this.response = {
         error : 'error',
@@ -27,8 +30,8 @@ function PoloniexCandles (client) {
         amount : 'amount'
     };
 
-    this.nextStart = function (data) {
-        return moment(_.last(data).date).add(1, 's').unix();
+    this.nextEnd = function (data) {
+        return moment(_.first(data).date).subtract(1, 's').unix();
     };
 
     this.acceptTrades = function (results, data) {

--- a/tasks/candles.js
+++ b/tasks/candles.js
@@ -11,6 +11,11 @@ module.exports = function (grunt) {
 
         async.series([
             function (callback) {
+                // Skip exchange if not enabled
+                if (!config.marketWatcher.exchanges.poloniex) {
+                    return callback(null);
+                }
+
                 var poloniex = new candles.poloniex(client);
 
                 poloniex.buildCandles(function (err, res) {
@@ -22,6 +27,11 @@ module.exports = function (grunt) {
                 });
             },
             function (callback) {
+                // Skip exchange if not enabled
+                if (!config.marketWatcher.exchanges.bittrex) {
+                    return callback(null);
+                }
+
                 var bittrex = new candles.bittrex(client);
 
                 bittrex.buildCandles(function (err, res) {
@@ -48,6 +58,11 @@ module.exports = function (grunt) {
 
         async.series([
             function (callback) {
+                // Skip exchange if not enabled
+                if (!config.marketWatcher.exchanges.poloniex) {
+                    return callback(null);
+                }
+
                 var poloniex = new candles.poloniex(client);
 
                 poloniex.updateCandles(function (err, res) {
@@ -59,6 +74,11 @@ module.exports = function (grunt) {
                 });
             },
             function (callback) {
+                // Skip exchange if not enabled
+                if (!config.marketWatcher.exchanges.bittrex) {
+                    return callback(null);
+                }
+
                 var bittrex = new candles.bittrex(client);
 
                 bittrex.updateCandles(function (err, res) {

--- a/tasks/candles.js
+++ b/tasks/candles.js
@@ -16,7 +16,7 @@ module.exports = function (grunt) {
                     return callback(null);
                 }
 
-                var poloniex = new candles.poloniex(client);
+                var poloniex = new candles.poloniex(client, config.marketWatcher.candles.poloniex);
 
                 poloniex.buildCandles(function (err, res) {
                     if (err) {

--- a/test/api/exchanges.js
+++ b/test/api/exchanges.js
@@ -31,7 +31,7 @@ describe('Exchanges API (Market Watcher)', function () {
                     'btcVolume',
                     'firstTrade',
                     'lastTrade',
-                    'nextStart',
+                    'nextEnd',
                     'numTrades'
                 );
             }

--- a/test/config.test
+++ b/test/config.test
@@ -38,6 +38,7 @@ config.marketWatcher.enabled = false; // Market watcher support (true - enabled,
 config.marketWatcher.exchanges.poloniex = true; // Poloniex exchange support (true - enabled, false - disabled)
 config.marketWatcher.exchanges.bittrex  = true; // Bittrex exchange support (true - enabled, false - disabled)
 config.marketWatcher.candles.updateInterval = 30000; // Interval in ms for updating candlestick data (default: 30 seconds)
+config.marketWatcher.candles.poloniex.buildTimeframe = 60*60*24*30; // Build candles based on trades form last 30 days
 config.marketWatcher.orders.updateInterval  = 15000;  // Interval in ms for updating order book data (default: 15 seconds)
 
 // Delegate Proposals


### PR DESCRIPTION
- Skip exchange if not enabled during `candles:build` task
- Adjust candles to modifications in Poloniex API
- Improve candles performance - get trades once, then generate candles for all periods
- Allow dynamic timeframe for build candles for Poloniex

Closes https://github.com/ArkEcosystem/ark-explorer/issues/34